### PR TITLE
Fixed recursive call to toString() method in BinaryTreenode class.

### DIFF
--- a/src/chapter06trees/BinaryTreeNode.java
+++ b/src/chapter06trees/BinaryTreeNode.java
@@ -75,7 +75,7 @@ public class BinaryTreeNode {
 		}
 		else {
 			    String root, left = "null", right = "null";
-			    root = this.toString();
+			    root = this.toString1();
 			    if (getLeft() != null) {
 					left = getLeft().toString();
 			    }

--- a/src/chapter06trees/BinaryTreeNode.java
+++ b/src/chapter06trees/BinaryTreeNode.java
@@ -71,7 +71,7 @@ public class BinaryTreeNode {
 	// Returns a String representation of this BinaryTreeNode.
 	public String toString() {
 		if (isLeaf()) {
-			return this.toString();
+			return this.toString1();
 		}
 		else {
 			    String root, left = "null", right = "null";

--- a/src/chapter06trees/PreOrderRecursive.java
+++ b/src/chapter06trees/PreOrderRecursive.java
@@ -15,8 +15,8 @@ package chapter06trees;
 public class PreOrderRecursive {
 	public void PreOrder(BinaryTreeNode root){
 		if(root != null) {
+			System.out.println(root.data);		
 			PreOrder(root.getLeft());
-			System.out.println(root.data);
 			PreOrder(root.right);
 		}
 	}


### PR DESCRIPTION
Hi Narasimha,
I think using toString() when a node is a leaf node will cause a java.lang.StackOverflowError.
Using toString1() solves the issue.

Accept the answer if it's ok.
Thank you,
Ayusman